### PR TITLE
Fix DecimalMath::productWithoutBC for values larger than 2^63−1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ the [Wikidata project](https://www.wikidata.org/).
 
 ## Release notes
 
+### 0.11.1 (TBD)
+
+* Fix `DecimalMath::productWithoutBC` for products larger than 2^63-1 (the maximum value of a signed 64 bit integer).
+
 ### 0.11.0 (2021-03-15)
 
- * Drop support for php versions older than 7.2 and HHVM
+* Drop support for php versions older than 7.2 and HHVM
  
 ### 0.10.2 (2021-03-15)
 

--- a/src/DataValues/DecimalMath.php
+++ b/src/DataValues/DecimalMath.php
@@ -92,13 +92,13 @@ class DecimalMath {
 	private function productWithoutBC( DecimalValue $a, DecimalValue $b ) {
 		$product = $a->getValueFloat() * $b->getValueFloat();
 
-		// Append .0 for consistency, if the result is a whole number,
+		// Add a decimal digit (.0) for consistency, if the result is a whole number,
 		// but $a or $b were specified with decimal places.
 		if (
 			$product === floor( $product ) &&
 			$a->getFractionalPart() . $b->getFractionalPart() !== ''
 		) {
-			$product = strval( $product ) . '.0';
+			$product = ( new DecimalValue( $product ) )->getValue() . '.0';
 		}
 
 		return new DecimalValue( $product );

--- a/tests/DataValues/DecimalMathTest.php
+++ b/tests/DataValues/DecimalMathTest.php
@@ -129,6 +129,34 @@ class DecimalMathTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * @dataProvider productLargeFloatProvider
+	 */
+	public function testProductLargeFloat( $useBC, DecimalValue $a, DecimalValue $b, $regex ) {
+		$math = new DecimalMath( $useBC );
+
+		$actual = $math->product( $a, $b );
+		$this->assertRegExp( $regex, $actual->getValue() );
+
+		$actual = $math->product( $b, $a );
+		$this->assertRegExp( $regex, $actual->getValue() );
+	}
+
+	public function productLargeFloatProvider() {
+		$cases = [
+			[
+				new DecimalValue( '+1600000000000000000000000000000000000000000000' ),
+				new DecimalValue( '123.45' ),
+				'/^\+1975200000000000\d{32}\.\d+$/'
+			],
+		];
+
+		foreach ( $cases as $case ) {
+			yield array_merge( [ true ], $case );
+			yield array_merge( [ false ], $case );
+		}
+	}
+
+	/**
 	 * @dataProvider productWithBCProvider
 	 */
 	public function testProductWithBC( DecimalValue $a, DecimalValue $b, $value ) {


### PR DESCRIPTION
PHP switches to a exponential display if values are larger than 2^63-1 (the maximum value of a signed 64 bit integer).

Fixes https://phabricator.wikimedia.org/T278824