### PR TITLE
Compare uncertainties using assertEqualsWithDelta()

### DIFF
--- a/tests/DataValues/QuantityValueTest.php
+++ b/tests/DataValues/QuantityValueTest.php
@@ -288,7 +288,11 @@ class QuantityValueTest extends DataValuesTestBase {
 	 * @dataProvider getUncertaintyProvider
 	 */
 	public function testGetUncertainty( QuantityValue $quantity, $expected ) {
-		$this->assertSame( $expected, $quantity->getUncertainty() );
+		$this->assertEqualsWithDelta(
+			$expected,
+			$quantity->getUncertainty(),
+			0.0000000000001
+		);
 	}
 
 	public function getUncertaintyProvider() {


### PR DESCRIPTION
Up to PHPUnit 8.5.23, assertSame() compared floats using a delta of 0.0000000001 (it was changed to PHP_FLOAT_EPSILON in 8.5.24 and then to 0 in 8.5.30). Explicitly call assertEqualsWithDelta() to make the assertion work on newer PHPUnit versions; the chosen delta is the smallest number of the form 0.0*1 that still passes the test. (Note that it’s a smaller delta than PHPUnit’s previous default; however, it needs to be greater than PHP_FLOAT_EPSILON.)