### PR TITLE
Remove DATAVALUES_NUMBER_VERSION

### DIFF
--- a/Number.php
+++ b/Number.php
@@ -1,8 +1,0 @@
-<?php
-
-if ( defined( 'DATAVALUES_NUMBER_VERSION' ) ) {
-	// Do not initialize more than once.
-	return 1;
-}
-
-define( 'DATAVALUES_NUMBER_VERSION', '0.10.2' );

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,6 @@
 		"mediawiki/mediawiki-codesniffer": "34.0.0"
 	},
 	"autoload": {
-		"files" : [
-			"Number.php"
-		],
 		"psr-0": {
 			"DataValues\\": "src",
 			"ValueFormatters\\": "src",


### PR DESCRIPTION
We’d already forgotten to update it with the previous two releases, and we’ve also removed such constants from other data-values libraries.