### PR TITLE
Relax data-values/data-values version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ the [Wikidata project](https://www.wikidata.org/).
 
 ## Release notes
 
+### 0.12.1 (2022-10-21)
+
+* Allow use with data-values/data-values 3.1.0
+
 ### 0.12.0 (2022-10-21)
 
 * Improve compatibility with PHP 8.1;

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	},
 	"require": {
 		"php": ">=7.2",
-		"data-values/data-values": "~3.0.0|~2.0|~1.0|~0.1",
+		"data-values/data-values": "~3.0|~2.0|~1.0|~0.1",
 		"data-values/interfaces": "~1.0.0|~0.2.0",
 		"data-values/common": "1.0.0|~0.4.0|~0.3.0"
 	},


### PR DESCRIPTION
~3.0.0 means that 3.1.0 is excluded, which we don’t want; use ~3.0 instead for consistency with the other versions in this constraint. (Though I’d personally prefer to just use the caret operator.)