### PR TITLE
Fix hashes after serialization change

### DIFF
--- a/src/DataValues/QuantityValue.php
+++ b/src/DataValues/QuantityValue.php
@@ -130,6 +130,26 @@ class QuantityValue extends UnboundedQuantityValue {
 		$this->__construct( $amount, $unit, $upperBound, $lowerBound );
 	}
 
+	public function getSerializationForHash(): string {
+		// mimic a legacy serialization of __serialize() (amount + unit + upperBound + lowerBound)
+		$amountSerialization = method_exists( $this->amount, 'getSerializationForHash' )
+			? $this->amount->getSerializationForHash()
+			: serialize( $this->amount );
+		$unitSerialization = serialize( $this->unit );
+		$upperBoundSerialization = method_exists( $this->upperBound, 'getSerializationForHash' )
+			? $this->upperBound->getSerializationForHash()
+			: serialize( $this->upperBound );
+		$lowerBoundSerialization = method_exists( $this->lowerBound, 'getSerializationForHash' )
+			? $this->lowerBound->getSerializationForHash()
+			: serialize( $this->lowerBound );
+
+		$data = 'a:4:{i:0;' . $amountSerialization . 'i:1;' . $unitSerialization .
+			'i:2;' . $upperBoundSerialization . 'i:3;' . $lowerBoundSerialization . '}';
+
+		return 'C:' . strlen( static::class ) . ':"' . static::class .
+			'":' . strlen( $data ) . ':{' . $data . '}';
+	}
+
 	/**
 	 * Returns this quantity's upper bound.
 	 *

--- a/src/DataValues/UnboundedQuantityValue.php
+++ b/src/DataValues/UnboundedQuantityValue.php
@@ -139,6 +139,19 @@ class UnboundedQuantityValue extends DataValueObject {
 		$this->__construct( $amount, $unit );
 	}
 
+	public function getSerializationForHash(): string {
+		// mimic a legacy serialization of __serialize() (amount + unit)
+		$amountSerialization = method_exists( $this->amount, 'getSerializationForHash' )
+			? $this->amount->getSerializationForHash()
+			: serialize( $this->amount );
+		$unitSerialization = serialize( $this->unit );
+
+		$data = 'a:2:{i:0;' . $amountSerialization . 'i:1;' . $unitSerialization . '}';
+
+		return 'C:' . strlen( static::class ) . ':"' . static::class .
+			'":' . strlen( $data ) . ':{' . $data . '}';
+	}
+
 	/**
 	 * @see DataValue::getType
 	 *

--- a/tests/DataValues/QuantityValueTest.php
+++ b/tests/DataValues/QuantityValueTest.php
@@ -458,4 +458,26 @@ class QuantityValueTest extends DataValuesTestBase {
 		];
 	}
 
+	/** @dataProvider instanceWithHashProvider */
+	public function testGetHashStability( QuantityValue $quantity, string $hash ) {
+		$this->assertSame( $hash, $quantity->getHash() );
+	}
+
+	public function instanceWithHashProvider(): iterable {
+		// all hashes obtained from data-values/data-values==3.0.0 data-values/number==0.11.1 under PHP 7.2.34
+		yield '10+-1' => [
+			QuantityValue::newFromNumber( '+10', '1', '+11', '+9' ),
+			'2eb812346e6bbc1bc47ed7da130bfa5d',
+		];
+		yield '500 miles, or a little bit more' => [
+			QuantityValue::newFromNumber(
+				'+558.84719',
+				'http://www.wikidata.org/entity/Q253276',
+				'+558.84719',
+				'+558.84719'
+			),
+			'5fb8c57f9ba8225146b03abdbb45c431',
+		];
+	}
+
 }

--- a/tests/DataValues/UnboundedQuantityValueTest.php
+++ b/tests/DataValues/UnboundedQuantityValueTest.php
@@ -319,4 +319,21 @@ class UnboundedQuantityValueTest extends DataValuesTestBase {
 		];
 	}
 
+	/** @dataProvider instanceWithHashProvider */
+	public function testGetHashStability( UnboundedQuantityValue $quantity, string $hash ) {
+		$this->assertSame( $hash, $quantity->getHash() );
+	}
+
+	public function instanceWithHashProvider(): iterable {
+		// all hashes obtained from data-values/data-values==3.0.0 data-values/number==0.11.1 under PHP 7.2.34
+		yield '10+-1' => [
+			UnboundedQuantityValue::newFromNumber( '+10', '1' ),
+			'6fc1f325788cfea1bc9c869fbbfe7824',
+		];
+		yield '500 miles, or a little bit more' => [
+			UnboundedQuantityValue::newFromNumber( '+558.84719', 'http://www.wikidata.org/entity/Q253276' ),
+			'8caf675b471b8579d8adae2e9721dbc9',
+		];
+	}
+
 }


### PR DESCRIPTION
Because the serialization of quantity values involves complex objects (`DecimalValue` instances), the `getSerializationForHash()` implementation we inherit from `DataValueObject` isn’t good enough: we need to override it to also call `getSerializationForHash()` on the inner `DecimalValue` instances (amount, upper bound, lower bound).

The hashes for the tests were obtained inside a php:7.2 Docker container, after installing the specified versions with composer, inside a `php -a` shell.

Bug: T301249