### PR TITLE
Relax additional version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ the [Wikidata project](https://www.wikidata.org/).
 
 ## Release notes
 
+### 0.12.3 (2022-10-24)
+
+* Allow use with data-values/common 1.1.0 and data-values/interfaces 1.x
+
 ### 0.12.2 (2022-10-21)
 
 * Fix `QuantityValue` and `UnboundedQuantityValue` hashes to be identical to version 0.11.1.

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
 	"require": {
 		"php": ">=7.2",
 		"data-values/data-values": "~3.0|~2.0|~1.0|~0.1",
-		"data-values/interfaces": "~1.0.0|~0.2.0",
-		"data-values/common": "1.0.0|~0.4.0|~0.3.0"
+		"data-values/interfaces": "~1.0|~0.2.0",
+		"data-values/common": "~1.0|~0.4.0|~0.3.0"
 	},
 	"require-dev": {
 		"ext-bcmath": "*",


### PR DESCRIPTION
Very similar to 9b9aecb3ae (#141), we want newer versions of data-values/common and data-values/interfaces to be installable too. (Interfaces doesn’t have a newer version yet, but any 1.x version should be compatible according to semver.)