### PR TITLE
Support mediawiki-codesniffer@45.0.0, PHP 8.4 readiness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 dist: bionic
 
 php:
-  - 7.2
-  - 7.3
   - 7.4
   - 8.0
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=7.2",
+		"php": ">=7.4",
 		"data-values/data-values": "~3.0|~2.0|~1.0|~0.1",
 		"data-values/interfaces": "~1.0|~0.2.0",
 		"data-values/common": "~1.0|~0.4.0|~0.3.0"
@@ -31,7 +31,7 @@
 	"require-dev": {
 		"ext-bcmath": "*",
 		"phpunit/phpunit": "~8.5",
-		"mediawiki/mediawiki-codesniffer": "34.0.0"
+		"mediawiki/mediawiki-codesniffer": "45.0.0"
 	},
 	"autoload": {
 		"psr-0": {
@@ -53,5 +53,10 @@
 			"phpcs -p -s",
 			"phpunit"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/src/DataValues/DecimalMath.php
+++ b/src/DataValues/DecimalMath.php
@@ -238,6 +238,8 @@ class DecimalMath {
 		return $position;
 	}
 
+	// phpcs:disable Generic.Metrics.CyclomaticComplexity.TooHigh
+
 	/**
 	 * Returns the given value, with any insignificant digits removed or zeroed.
 	 *
@@ -315,6 +317,8 @@ class DecimalMath {
 
 		return $rounded;
 	}
+
+	// phpcs:enable
 
 	/**
 	 * Increment the least significant digit by one if it is less than 9, and

--- a/src/DataValues/DecimalValue.php
+++ b/src/DataValues/DecimalValue.php
@@ -98,8 +98,8 @@ class DecimalValue extends DataValueObject {
 		 * @see http://php.net/manual/en/ini.core.php#ini.serialize-precision
 		 */
 		$decimal = sprintf( '%.16e', abs( $number ) );
-		list( $base, $exponent ) = explode( 'e', $decimal );
-		list( $before, $after ) = explode( '.', $base );
+		[ $base, $exponent ] = explode( 'e', $decimal );
+		[ $before, $after ] = explode( '.', $base );
 
 		// Fill with as many zeros as necessary, and move the decimal point
 		if ( $exponent < 0 ) {
@@ -117,6 +117,8 @@ class DecimalValue extends DataValueObject {
 		// Remove not needed ".0" or just "." from the end
 		return ( $number < 0 ? '-' : '+' ) . $before . rtrim( rtrim( $after, '0' ), '.' );
 	}
+
+	// phpcs:disable Generic.Metrics.CyclomaticComplexity.TooHigh
 
 	/**
 	 * Compares this DecimalValue to another DecimalValue.
@@ -179,6 +181,8 @@ class DecimalValue extends DataValueObject {
 		$cmp = strcmp( $aFract, $bFract );
 		return $cmp === 0 ? 0 : ( $cmp < 0 ? -$sense : $sense );
 	}
+
+	// phpcs:enable
 
 	/**
 	 * @see Serializable::serialize

--- a/src/DataValues/QuantityValue.php
+++ b/src/DataValues/QuantityValue.php
@@ -126,7 +126,7 @@ class QuantityValue extends UnboundedQuantityValue {
 	}
 
 	public function __unserialize( array $data ): void {
-		list( $amount, $unit, $upperBound, $lowerBound ) = $data;
+		[ $amount, $unit, $upperBound, $lowerBound ] = $data;
 		$this->__construct( $amount, $unit, $upperBound, $lowerBound );
 	}
 

--- a/src/DataValues/UnboundedQuantityValue.php
+++ b/src/DataValues/UnboundedQuantityValue.php
@@ -85,7 +85,7 @@ class UnboundedQuantityValue extends DataValueObject {
 	 * @throws InvalidArgumentException
 	 * @return DecimalValue
 	 */
-	protected static function asDecimalValue( $name, $number, DecimalValue $default = null ) {
+	protected static function asDecimalValue( $name, $number, ?DecimalValue $default = null ) {
 		if ( !is_string( $name ) ) {
 			throw new InvalidArgumentException( '$name must be a string' );
 		}
@@ -135,7 +135,7 @@ class UnboundedQuantityValue extends DataValueObject {
 	}
 
 	public function __unserialize( array $data ): void {
-		list( $amount, $unit ) = $data;
+		[ $amount, $unit ] = $data;
 		$this->__construct( $amount, $unit );
 	}
 

--- a/src/ValueFormatters/DecimalFormatter.php
+++ b/src/ValueFormatters/DecimalFormatter.php
@@ -36,7 +36,7 @@ class DecimalFormatter implements ValueFormatter {
 	 * @param FormatterOptions|null $options
 	 * @param NumberLocalizer|null $localizer
 	 */
-	public function __construct( FormatterOptions $options = null, NumberLocalizer $localizer = null ) {
+	public function __construct( ?FormatterOptions $options = null, ?NumberLocalizer $localizer = null ) {
 		$this->options = $options ?: new FormatterOptions();
 
 		$this->options->defaultOption( ValueFormatter::OPT_LANG, 'en' );

--- a/src/ValueParsers/DecimalParser.php
+++ b/src/ValueParsers/DecimalParser.php
@@ -34,7 +34,7 @@ class DecimalParser extends StringValueParser {
 	 * @param ParserOptions|null $options
 	 * @param NumberUnlocalizer|null $unlocalizer
 	 */
-	public function __construct( ParserOptions $options = null, NumberUnlocalizer $unlocalizer = null ) {
+	public function __construct( ?ParserOptions $options = null, ?NumberUnlocalizer $unlocalizer = null ) {
 		parent::__construct( $options );
 
 		$this->unlocalizer = $unlocalizer ?: new BasicNumberUnlocalizer();
@@ -127,7 +127,7 @@ class DecimalParser extends StringValueParser {
 		$value = $this->unlocalizer->unlocalizeNumber( $value );
 
 		//handle scientific notation
-		list( $value, $exponent ) = $this->splitDecimalExponent( $value );
+		[ $value, $exponent ] = $this->splitDecimalExponent( $value );
 
 		$value = $this->normalizeDecimal( $value );
 

--- a/src/ValueParsers/QuantityParser.php
+++ b/src/ValueParsers/QuantityParser.php
@@ -44,7 +44,7 @@ class QuantityParser extends StringValueParser {
 	 * @param ParserOptions|null $options
 	 * @param NumberUnlocalizer|null $unlocalizer
 	 */
-	public function __construct( ParserOptions $options = null, NumberUnlocalizer $unlocalizer = null ) {
+	public function __construct( ?ParserOptions $options = null, ?NumberUnlocalizer $unlocalizer = null ) {
 		parent::__construct( $options );
 
 		$this->defaultOption( self::OPT_UNIT, null );
@@ -64,7 +64,7 @@ class QuantityParser extends StringValueParser {
 	 * @throws ParseException
 	 */
 	protected function stringParse( $value ) {
-		list( $amount, $exactness, $margin, $unit ) = $this->splitQuantityString( $value );
+		[ $amount, $exactness, $margin, $unit ] = $this->splitQuantityString( $value );
 
 		$unitOption = $this->getUnitFromOptions();
 
@@ -106,7 +106,7 @@ class QuantityParser extends StringValueParser {
 	 * @return UnboundedQuantityValue|QuantityValue
 	 */
 	private function newQuantityFromParts( $amount, $exactness, $margin, $unit ) {
-		list( $amount, $exponent ) = $this->decimalParser->splitDecimalExponent( $amount );
+		[ $amount, $exponent ] = $this->decimalParser->splitDecimalExponent( $amount );
 		$amountValue = $this->decimalParser->parse( $amount );
 
 		if ( $exactness === '!' ) {
@@ -166,7 +166,7 @@ class QuantityParser extends StringValueParser {
 		// Remove $0.
 		array_shift( $groups );
 
-		array_walk( $groups, function ( &$element ) {
+		array_walk( $groups, static function ( &$element ) {
 			if ( $element === '' ) {
 				$element = null;
 			}

--- a/tests/DataValues/DataValuesTestBase.php
+++ b/tests/DataValues/DataValuesTestBase.php
@@ -38,7 +38,7 @@ class DataValuesTestBase extends TestCase {
 		$instanceBuilder = [ $this, 'newInstance' ];
 
 		return array_map(
-			function ( array $args ) use ( $instanceBuilder ) {
+			static function ( array $args ) use ( $instanceBuilder ) {
 				return [
 					call_user_func_array( $instanceBuilder, $args ),
 					$args

--- a/tests/DataValues/DecimalMathTest.php
+++ b/tests/DataValues/DecimalMathTest.php
@@ -16,7 +16,7 @@ use DataValues\DecimalValue;
  */
 class DecimalMathTest extends \PHPUnit\Framework\TestCase {
 
-	public function setUp() : void {
+	public function setUp(): void {
 		if ( !\extension_loaded( 'bcmath' ) ) {
 			$this->markTestSkipped( 'bcmath extension not loaded' );
 		}

--- a/tests/DataValues/DecimalValueTest.php
+++ b/tests/DataValues/DecimalValueTest.php
@@ -370,9 +370,9 @@ class DecimalValueTest extends TestCase {
 			[ new DecimalValue( '+0' ), true ],
 			[ new DecimalValue( '-0.00' ), true ],
 
-			[ new DecimalValue( '+1' ),       false ],
+			[ new DecimalValue( '+1' ), false ],
 			[ new DecimalValue( '+100.663' ), false ],
-			[ new DecimalValue( '-0.001' ),   false ],
+			[ new DecimalValue( '-0.001' ), false ],
 		];
 	}
 
@@ -386,14 +386,14 @@ class DecimalValueTest extends TestCase {
 
 	public function provideGetTrim() {
 		return [
-			[ new DecimalValue( '+8' ),     new DecimalValue( '+8' ) ],
-			[ new DecimalValue( '+80' ),    new DecimalValue( '+80' ) ],
-			[ new DecimalValue( '+800' ),   new DecimalValue( '+800' ) ],
-			[ new DecimalValue( '+0' ),     new DecimalValue( '+0' ) ],
-			[ new DecimalValue( '+0.0' ),   new DecimalValue( '+0' ) ],
+			[ new DecimalValue( '+8' ), new DecimalValue( '+8' ) ],
+			[ new DecimalValue( '+80' ), new DecimalValue( '+80' ) ],
+			[ new DecimalValue( '+800' ), new DecimalValue( '+800' ) ],
+			[ new DecimalValue( '+0' ), new DecimalValue( '+0' ) ],
+			[ new DecimalValue( '+0.0' ), new DecimalValue( '+0' ) ],
 			[ new DecimalValue( '+10.00' ), new DecimalValue( '+10' ) ],
-			[ new DecimalValue( '-0.1' ),   new DecimalValue( '-0.1' ) ],
-			[ new DecimalValue( '-0.10' ),  new DecimalValue( '-0.1' ) ],
+			[ new DecimalValue( '-0.1' ), new DecimalValue( '-0.1' ) ],
+			[ new DecimalValue( '-0.10' ), new DecimalValue( '-0.1' ) ],
 			[ new DecimalValue( '-0.010' ), new DecimalValue( '-0.01' ) ],
 			[ new DecimalValue( '-0.001' ), new DecimalValue( '-0.001' ) ],
 		];

--- a/tests/DataValues/QuantityValueTest.php
+++ b/tests/DataValues/QuantityValueTest.php
@@ -387,16 +387,16 @@ class QuantityValueTest extends DataValuesTestBase {
 	}
 
 	public function transformProvider() {
-		$identity = function ( DecimalValue $value ) {
+		$identity = static function ( DecimalValue $value ) {
 			return $value;
 		};
 
-		$square = function ( DecimalValue $value ) {
+		$square = static function ( DecimalValue $value ) {
 			$v = $value->getValueFloat();
 			return new DecimalValue( $v * $v * $v );
 		};
 
-		$scale = function ( DecimalValue $value, $factor ) {
+		$scale = static function ( DecimalValue $value, $factor ) {
 			return new DecimalValue( $value->getValueFloat() * $factor );
 		};
 

--- a/tests/DataValues/UnboundedQuantityValueTest.php
+++ b/tests/DataValues/UnboundedQuantityValueTest.php
@@ -262,16 +262,16 @@ class UnboundedQuantityValueTest extends DataValuesTestBase {
 	}
 
 	public function transformProvider() {
-		$identity = function ( DecimalValue $value ) {
+		$identity = static function ( DecimalValue $value ) {
 			return $value;
 		};
 
-		$square = function ( DecimalValue $value ) {
+		$square = static function ( DecimalValue $value ) {
 			$v = $value->getValueFloat();
 			return new DecimalValue( $v * $v * $v );
 		};
 
-		$scale = function ( DecimalValue $value, $factor ) {
+		$scale = static function ( DecimalValue $value, $factor ) {
 			return new DecimalValue( $value->getValueFloat() * $factor );
 		};
 

--- a/tests/ValueFormatters/DecimalFormatterTest.php
+++ b/tests/ValueFormatters/DecimalFormatterTest.php
@@ -26,7 +26,7 @@ class DecimalFormatterTest extends TestCase {
 	 *
 	 * @return DecimalFormatter
 	 */
-	protected function getInstance( FormatterOptions $options = null ) {
+	protected function getInstance( ?FormatterOptions $options = null ) {
 		return new DecimalFormatter( $options );
 	}
 
@@ -62,9 +62,9 @@ class DecimalFormatterTest extends TestCase {
 
 		$localizer->expects( $this->once() )
 			->method( 'localizeNumber' )
-			->will( $this->returnCallback( function ( $number ) {
+			->willReturnCallback( static function ( $number ) {
 				return "n:$number";
-			} ) );
+			} );
 
 		$value = new DecimalValue( '+12345' );
 		$formatter = new DecimalFormatter( null, $localizer );

--- a/tests/ValueFormatters/QuantityFormatterTest.php
+++ b/tests/ValueFormatters/QuantityFormatterTest.php
@@ -21,7 +21,7 @@ use ValueFormatters\ValueFormatter;
  */
 class QuantityFormatterTest extends TestCase {
 
-	public function setUp() : void {
+	public function setUp(): void {
 		if ( !\extension_loaded( 'bcmath' ) ) {
 			$this->markTestSkipped( 'bcmath extension not loaded' );
 		}
@@ -34,7 +34,7 @@ class QuantityFormatterTest extends TestCase {
 	 *
 	 * @return QuantityFormatter
 	 */
-	protected function getInstance( FormatterOptions $options = null ) {
+	protected function getInstance( ?FormatterOptions $options = null ) {
 		return $this->getQuantityFormatter( $options );
 	}
 
@@ -45,15 +45,15 @@ class QuantityFormatterTest extends TestCase {
 	 * @return QuantityFormatter
 	 */
 	private function getQuantityFormatter(
-		FormatterOptions $options = null,
-		$quantityWithUnitFormat = null
+		?FormatterOptions $options = null,
+		?string $quantityWithUnitFormat = null
 	) {
 		$vocabularyUriFormatter = $this->createMock( ValueFormatter::class );
 		$vocabularyUriFormatter->expects( $this->any() )
 			->method( 'format' )
-			->will( $this->returnCallback( function ( $unit ) {
+			->willReturnCallback( static function ( $unit ) {
 				return $unit === '1' ? null : $unit;
-			} ) );
+			} );
 
 		return new QuantityFormatter(
 			$options,

--- a/tests/ValueFormatters/QuantityHtmlFormatterTest.php
+++ b/tests/ValueFormatters/QuantityHtmlFormatterTest.php
@@ -26,28 +26,21 @@ class QuantityHtmlFormatterTest extends TestCase {
 	 *
 	 * @return QuantityHtmlFormatter
 	 */
-	protected function getInstance( FormatterOptions $options = null ) {
+	protected function getInstance( ?FormatterOptions $options = null ) {
 		return $this->getQuantityHtmlFormatter( $options );
 	}
 
-	/**
-	 * @param FormatterOptions|null $options
-	 * @param DecimalFormatter|null $decimalFormatter
-	 * @param string|null $quantityWithUnitFormat
-	 *
-	 * @return QuantityHtmlFormatter
-	 */
 	private function getQuantityHtmlFormatter(
-		FormatterOptions $options = null,
-		DecimalFormatter $decimalFormatter = null,
-		$quantityWithUnitFormat = null
-	) {
+		?FormatterOptions $options = null,
+		?DecimalFormatter $decimalFormatter = null,
+		?string $quantityWithUnitFormat = null
+	): QuantityHtmlFormatter {
 		$vocabularyUriFormatter = $this->createMock( ValueFormatter::class );
 		$vocabularyUriFormatter->expects( $this->any() )
 			->method( 'format' )
-			->will( $this->returnCallback( function ( $unit ) {
+			->willReturnCallback( static function ( $unit ) {
 				return $unit === '1' ? null : $unit;
-			} ) );
+			} );
 
 		return new QuantityHtmlFormatter(
 			$options,
@@ -70,11 +63,11 @@ class QuantityHtmlFormatterTest extends TestCase {
 
 		$quantity->expects( $this->any() )
 			->method( 'getAmount' )
-			->will( $this->returnValue( new DecimalValue( 2 ) ) );
+			->willReturn( new DecimalValue( 2 ) );
 		if ( $className === QuantityValue::class ) {
 			$quantity->expects( $this->any() )
 				->method( 'getUncertaintyMargin' )
-				->will( $this->returnValue( new DecimalValue( $uncertaintyMargin ) ) );
+				->willReturn( new DecimalValue( $uncertaintyMargin ) );
 		}
 
 		return $quantity;
@@ -126,7 +119,7 @@ class QuantityHtmlFormatterTest extends TestCase {
 		$decimalFormatter = $this->createMock( DecimalFormatter::class );
 		$decimalFormatter->expects( $this->any() )
 			->method( 'format' )
-			->will( $this->returnValue( '<b>+2</b>' ) );
+			->willReturn( '<b>+2</b>' );
 
 		$formatter = $this->getQuantityHtmlFormatter( $options, $decimalFormatter );
 		$formatted = $formatter->format( $value );

--- a/tests/ValueParsers/DecimalParserTest.php
+++ b/tests/ValueParsers/DecimalParserTest.php
@@ -23,7 +23,7 @@ class DecimalParserTest extends ValueParserTestCase {
 	protected function getInstance() {
 		$unlocalizer = $this->createMock( NumberUnlocalizer::class );
 		$unlocalizer->method( 'unlocalizeNumber' )
-			->will( $this->returnArgument( 0 ) );
+			->willReturnArgument( 0 );
 
 		return new DecimalParser( null, $unlocalizer );
 	}
@@ -119,9 +119,9 @@ class DecimalParserTest extends ValueParserTestCase {
 
 		$unlocalizer->expects( $this->once() )
 			->method( 'unlocalizeNumber' )
-			->will( $this->returnCallback( function ( $number ) {
+			->willReturnCallback( static function ( $number ) {
 				return str_replace( '#', '', $number );
-			} ) );
+			} );
 
 		$unlocalizer->expects( $this->never() )
 			->method( 'getNumberRegex' );
@@ -160,7 +160,7 @@ class DecimalParserTest extends ValueParserTestCase {
 	 */
 	public function testSplitDecimalExponent( $valueString, $expectedDecimal, $expectedExponent ) {
 		$parser = new DecimalParser();
-		list( $decimal, $exponent ) = $parser->splitDecimalExponent( $valueString );
+		[ $decimal, $exponent ] = $parser->splitDecimalExponent( $valueString );
 
 		$this->assertSame( $expectedDecimal, $decimal );
 		$this->assertSame( $expectedExponent, $exponent );

--- a/tests/ValueParsers/QuantityParserTest.php
+++ b/tests/ValueParsers/QuantityParserTest.php
@@ -21,7 +21,7 @@ use ValueParsers\ValueParser;
  */
 class QuantityParserTest extends ValueParserTestCase {
 
-	public function setUp() : void {
+	public function setUp(): void {
 		if ( !\extension_loaded( 'bcmath' ) ) {
 			$this->markTestSkipped( 'bcmath extension not loaded' );
 		}
@@ -41,22 +41,22 @@ class QuantityParserTest extends ValueParserTestCase {
 	 *
 	 * @return QuantityParser
 	 */
-	private function getQuantityParser( ParserOptions $options = null ) {
+	private function getQuantityParser( ?ParserOptions $options = null ) {
 		$unlocalizer = $this->createMock( NumberUnlocalizer::class );
 
 		$unlocalizer->expects( $this->any() )
 			->method( 'unlocalizeNumber' )
-			->will( $this->returnArgument( 0 ) );
+			->willReturnArgument( 0 );
 
 		// The most minimal regex that accepts all the test cases below.
 		$unlocalizer->expects( $this->any() )
 			->method( 'getNumberRegex' )
-			->will( $this->returnValue( '[-+]? *(?:\d+\.\d*|\.?\d+)(?:e-?\d+)?' ) );
+			->willReturn( '[-+]? *(?:\d+\.\d*|\.?\d+)(?:e-?\d+)?' );
 
 		// This minimal regex supports % and letters, optionally followed by a digit.
 		$unlocalizer->expects( $this->any() )
 			->method( 'getUnitRegex' )
-			->will( $this->returnValue( '[\p{L}%]+[\d³]?' ) );
+			->willReturn( '[\p{L}%]+[\d³]?' );
 
 		return new QuantityParser( $options, $unlocalizer );
 	}
@@ -217,19 +217,19 @@ class QuantityParserTest extends ValueParserTestCase {
 
 		$unlocalizer->expects( $this->any() )
 			->method( 'unlocalizeNumber' )
-			->will( $this->returnCallback(
-				function ( $number ) use ( $charmap ) {
+			->willReturnCallback(
+				static function ( $number ) use ( $charmap ) {
 					return str_replace( array_keys( $charmap ), array_values( $charmap ), $number );
 				}
-			) );
+			);
 
 		$unlocalizer->expects( $this->any() )
 			->method( 'getNumberRegex' )
-			->will( $this->returnValue( '[\d ]+(?:,\d+)?' ) );
+			->willReturn( '[\d ]+(?:,\d+)?' );
 
 		$unlocalizer->expects( $this->any() )
 			->method( 'getUnitRegex' )
-			->will( $this->returnValue( '[a-z~]+' ) );
+			->willReturn( '[a-z~]+' );
 
 		$parser = new QuantityParser( $options, $unlocalizer );
 

--- a/tests/ValueParsers/ValueParserTestCase.php
+++ b/tests/ValueParsers/ValueParserTestCase.php
@@ -50,7 +50,7 @@ abstract class ValueParserTestCase extends TestCase {
 	 * @param mixed $expected
 	 * @param ValueParser|null $parser
 	 */
-	public function testParseWithValidInputs( $value, $expected, ValueParser $parser = null ) {
+	public function testParseWithValidInputs( $value, $expected, ?ValueParser $parser = null ) {
 		if ( $parser === null ) {
 			$parser = $this->getInstance();
 		}
@@ -85,7 +85,7 @@ abstract class ValueParserTestCase extends TestCase {
 	 * @param mixed $value
 	 * @param ValueParser|null $parser
 	 */
-	public function testParseWithInvalidInputs( $value, ValueParser $parser = null ) {
+	public function testParseWithInvalidInputs( $value, ?ValueParser $parser = null ) {
 		if ( $parser === null ) {
 			$parser = $this->getInstance();
 		}


### PR DESCRIPTION
This repository is currently using version 34 of the Mediawiki coding style phpcs rules. It should be upgraded to the latest version.

Besides being simply different, the newer versions of the rules introduce, for example,
MediaWiki.Usage.NullableType.ExplicitNullableTypes, which enforces compliance with coming deprecation rules in PHP 8.4 concerning nullable types. If the code does not remove the soon-to-be-deprecated form of nullable type declarations, the library will no longer be usable in Mediawiki for PHP 8.4 deployments.

Bug: T379481